### PR TITLE
Update date and age to make UTC time explicit for blocks.

### DIFF
--- a/client/src/components/TimeSince.vue
+++ b/client/src/components/TimeSince.vue
@@ -6,6 +6,8 @@
     </span>
 </template>
 <script>
+import moment from 'moment'
+
 export default {
   name: 'TimeSince',
   data() {
@@ -41,7 +43,9 @@ export default {
   },
   methods: {
     updateDateAge() {
-      let diff = Math.abs(Date.now() - (new Date(this.date)).getTime())
+      let now = moment.utc()
+      let date = moment(this.date, 'YYYY-MM-DD HH:mm:ss').utc()
+      let diff = now.diff(date)
       this.years = Math.floor(diff / this.intervals.year)
       diff -= this.years * this.intervals.year
       this.days = Math.floor(diff / this.intervals.day)

--- a/client/src/format.js
+++ b/client/src/format.js
@@ -43,9 +43,9 @@ const formatBlock = (block) => {
     height: block.height.compact(),
     hash: block.hash,
     timestamp: block.timestamp.compact() / 1000 + 1459468800,
-    date: moment(
+    date: moment.utc(
       (block.timestamp.compact() / 1000 + 1459468800) * 1000
-    ).format('YYYY-MM-DD HH:mm:ss'),
+    ).local().format('YYYY-MM-DD HH:mm:ss'),
     totalFee: block.totalFee.compact(),
     difficulty: (block.difficulty.compact() / 1000000000000).toFixed(2),
     numTransactions: block.numTransactions ? block.numTransactions : 0,


### PR DESCRIPTION
Should patch #55 by ensuring all time delta calculations are done in UTC time, while the displayed time is done in local time.
The issue seems to have been a time-zone issue (the delta is ~5 hours from UTC), so although much of this code is overly explicit, it ensures correctness.