### PR TITLE
Issue #71: Reusable component Chart.vue added

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "apexcharts": "^3.8.5",
+    "apexcharts": "^3.8.6",
     "axios": "^0.19.0",
     "chart.js": "^2.8.0",
     "core-js": "^2.6.5",
@@ -16,6 +16,7 @@
     "socket.io": "^2.2.0",
     "socket.io-client": "^2.2.0",
     "vue": "^2.6.10",
+    "vue-apexcharts": "^1.5.0",
     "vue-clipboard2": "^0.3.1",
     "vue-router": "^3.0.3",
     "vue-slim-tabs": "^0.3.0",

--- a/client/src/components/Chart.vue
+++ b/client/src/components/Chart.vue
@@ -1,0 +1,139 @@
+<template>
+    <div>
+        <apexchart 
+            :width="width" 
+            :height="height"
+            :type="type" 
+            :options="options" 
+            :series="series"
+        >
+        </apexchart>
+    </div>
+</template>
+
+
+
+<script>
+import VueApexCharts from 'vue-apexcharts'
+
+export default {
+    components: {
+        'apexchart': VueApexCharts
+    },
+
+    props: {
+        data: {
+            type: Array,
+            required: true
+        },
+
+        type: {
+            type: String,
+            required: true,
+            default: "line"
+        },
+
+        height: {
+            type: Number,
+            default: 200
+        },
+
+        width: {
+            type: Number,
+            default: void 0
+        },
+
+        colors: {
+            type: Array,
+            default: ["#1eaaa6", "#f2e013", "#f29913"]
+        },
+
+        toolbar: {
+            type: Boolean,
+            default: false
+        }
+
+    },
+
+    data() {
+        return {
+            options: {
+                chart: {
+                    foreColor: "#999",
+                    toolbar: {
+                        show: this.toolbar,
+                        tools: {
+                            download: false,
+                            selection: true,
+                            zoom: false,
+                            zoomin: true,
+                            zoomout: true,
+                            pan: '<i class="ico-arrow-move" style="font-size: 24px;"></i>',
+                            reset: '<i class="ico-ios-refresh-outline" style="font-size: 22px;"></i>',
+                            customIcons: []
+                        }
+                    }
+                },
+                stroke: {
+                    show: true,
+                    curve: "smooth",
+                    lineCap: "butt",
+                    width: 2,
+                    dashArray: 0
+                },
+                dataLabels: {
+                    enabled: false
+                },
+                colors: this.colors,
+                fill: {
+                    gradient: {
+                        enabled: true,
+                        opacityFrom: 1,
+                        opacityTo: 0.7
+                    }
+                },
+                plotOptions: {
+                    candlestick: {
+                        colors: {
+                            upward: "#0998a6",
+                            downward: "#f7a800"
+                        },
+                        wick: {
+                            useFillColor: true
+                        }
+                    }
+                },
+                title: {
+                    display: false
+                },
+                xaxis: {
+                    type: "datetime",
+                    axisBorder: {
+                        show: false,
+                        color: "#0998a6"
+                    }
+                },
+                yaxis: {
+                    tooltip: {
+                        enabled: false
+                    },
+                    axisBorder: {
+                        show: false,
+                        color: "#0998a6"
+                    }
+                },
+                tooltip: {
+                    enabled: true
+                }
+            }
+        }
+    },
+
+    computed: {
+        series() {
+            return this.data;
+        }
+    }
+
+}
+</script>


### PR DESCRIPTION
#71 
Fixes:
> ApexGraph integration is using pure javascript integration, can be made with Vue as well

Input properties:
- **data** (required). Chart series data. Format: 

```
[
{
"name": "String. Series name",
"data": [
{
"x": "Number. Unix timestamp",
"y": "Number. Value"
}
]
}
]
```

- **type** (required). [Accepted values](https://apexcharts.com/docs/options/chart/type/)

- **height**

- **width**

- **colors**. Array of colors (Strings)

- **toolbar**. Boolean. Whether to show toolbar
