### PR TITLE
Patch the HTTP methods to use the current node from the store.

### DIFF
--- a/src/infrastructure/getAccount.js
+++ b/src/infrastructure/getAccount.js
@@ -21,10 +21,6 @@ import http from './http'
 import format from '../format'
 
 class sdkAccount {
-  // TODO(ahuszagh) Remove
-  static init = async nodeUrl => {
-  }
-
   static getAccountInfoByAddress = async address => {
     let addressObj = Address.createFromRawAddress(address)
 

--- a/src/infrastructure/getAccount.js
+++ b/src/infrastructure/getAccount.js
@@ -17,23 +17,22 @@
  */
 
 import { AccountHttp, Address } from 'nem2-sdk'
+import http from './http'
 import format from '../format'
 
-let ACCOUNT_HTTP
-
 class sdkAccount {
+  // TODO(ahuszagh) Remove
   static init = async nodeUrl => {
-    ACCOUNT_HTTP = new AccountHttp(nodeUrl)
   }
 
   static getAccountInfoByAddress = async address => {
     let addressObj = Address.createFromRawAddress(address)
 
-    const accountInfo = await ACCOUNT_HTTP
+    const accountInfo = await http.account
       .getAccountInfo(addressObj)
       .toPromise()
 
-    const accountNames = await ACCOUNT_HTTP
+    const accountNames = await http.account
       .getAccountsNames([addressObj])
       .toPromise()
 
@@ -45,7 +44,7 @@ class sdkAccount {
     let accountMultisig
 
     try {
-      accountMultisig = await ACCOUNT_HTTP
+      accountMultisig = await http.account
         .getMultisigAccountInfo(addressObj)
         .toPromise()
     } catch (e) {

--- a/src/infrastructure/getBlock.js
+++ b/src/infrastructure/getBlock.js
@@ -17,31 +17,23 @@
  */
 
 import axios from 'axios'
-import { BlockHttp, ChainHttp, NetworkHttp, QueryParams } from 'nem2-sdk'
+import { QueryParams } from 'nem2-sdk'
 import dto from './dto'
+import http from './http'
 import format from '../format'
 
-
-let CHAIN_HTTP
-let BLOCK_HTTP
-let NETWORK_HTTP
-let NODE_URL
-
 class sdkBlock {
+  // TODO(ahuszagh) Remove
   static init = async nodeUrl => {
-    NODE_URL = nodeUrl
-    CHAIN_HTTP = new ChainHttp(nodeUrl)
-    BLOCK_HTTP = new BlockHttp(nodeUrl)
-    NETWORK_HTTP = new NetworkHttp(nodeUrl)
   }
 
   static getBlockHeight = async () => {
-    const blockHeight = await CHAIN_HTTP.getBlockchainHeight().toPromise()
+    const blockHeight = await http.chain.getBlockchainHeight().toPromise()
     return blockHeight.compact()
   }
 
   static getBlockInfoByHeight = async (blockHeight) => {
-    const blockInfo = await BLOCK_HTTP.getBlockByHeight(blockHeight).toPromise()
+    const blockInfo = await http.block.getBlockByHeight(blockHeight).toPromise()
     return format.formatBlock(blockInfo)
   }
 
@@ -58,7 +50,7 @@ class sdkBlock {
     transactionId = transactionId || ''
     const pageSize = 100
 
-    let transactions = await BLOCK_HTTP
+    let transactions = await http.block
       .getBlockTransactions(blockHeight, new QueryParams(pageSize, transactionId))
       .toPromise()
 
@@ -74,9 +66,9 @@ class sdkBlock {
     }
 
     // Make request.
-    const networkType = await NETWORK_HTTP.getNetworkType().toPromise()
+    const networkType = await http.network.getNetworkType().toPromise()
     const path = `/blocks/from/${blockHeight}/limit/${limit}`
-    const response = await axios.get(NODE_URL + path)
+    const response = await axios.get(http.url + path)
     const blocks = response.data.map(info => dto.createBlockFromDTO(info, networkType))
 
     return format.formatBlocks(blocks)
@@ -91,9 +83,9 @@ class sdkBlock {
     }
 
     // Make request.
-    const networkType = await NETWORK_HTTP.getNetworkType().toPromise()
+    const networkType = await http.network.getNetworkType().toPromise()
     const path = `/blocks/since/${blockHeight}/limit/${limit}`
-    const response = await axios.get(NODE_URL + path)
+    const response = await axios.get(http.url + path)
     const blocks = response.data.map(info => dto.createBlockFromDTO(info, networkType))
 
     return format.formatBlocks(blocks)

--- a/src/infrastructure/getBlock.js
+++ b/src/infrastructure/getBlock.js
@@ -23,10 +23,6 @@ import http from './http'
 import format from '../format'
 
 class sdkBlock {
-  // TODO(ahuszagh) Remove
-  static init = async nodeUrl => {
-  }
-
   static getBlockHeight = async () => {
     const blockHeight = await http.chain.getBlockchainHeight().toPromise()
     return blockHeight.compact()

--- a/src/infrastructure/getDiagnostic.js
+++ b/src/infrastructure/getDiagnostic.js
@@ -16,16 +16,15 @@
  *
  */
 
-import { DiagnosticHttp } from 'nem2-sdk'
-
-let DIAGNOSTIC_HTTP
+import http from './http'
 
 class sdkDiagnostic {
+    // TODO(ahuszagh) Remove
     static init = async nodeUrl => {
-        DIAGNOSTIC_HTTP = new DiagnosticHttp(nodeUrl)
     }
+
     static getChainInfo = async () => {
-        const chainInfo = await DIAGNOSTIC_HTTP.getDiagnosticStorage().toPromise()
+        const chainInfo = await http.diagnostic.getDiagnosticStorage().toPromise()
         return chainInfo
     }
 }

--- a/src/infrastructure/getDiagnostic.js
+++ b/src/infrastructure/getDiagnostic.js
@@ -19,10 +19,6 @@
 import http from './http'
 
 class sdkDiagnostic {
-    // TODO(ahuszagh) Remove
-    static init = async nodeUrl => {
-    }
-
     static getChainInfo = async () => {
         const chainInfo = await http.diagnostic.getDiagnosticStorage().toPromise()
         return chainInfo

--- a/src/infrastructure/getMosaic.js
+++ b/src/infrastructure/getMosaic.js
@@ -26,10 +26,6 @@ import http from './http'
 import format from '../format'
 
 class sdkMosaic {
-  // TODO(ahuszagh) Remove
-  static init = async nodeUrl => {
-  }
-
   static getMosaicsAmountByAddress = async address => {
     const mosaicAmount = await http.mosaicService
       .mosaicsAmountViewFromAddress(new Address(address))

--- a/src/infrastructure/getMosaic.js
+++ b/src/infrastructure/getMosaic.js
@@ -18,35 +18,20 @@
 
 import axios from 'axios'
 import {
-  MosaicService,
-  Address,
-  AccountHttp,
-  MosaicHttp,
-  NetworkHttp
+  Address
 } from 'nem2-sdk'
 
-import format from '../format'
 import dto from './dto'
-
-let ACCOUNT_HTTP
-let MOSAIC_HTTP
-let NETWORK_HTTP
-let NODE_URL
+import http from './http'
+import format from '../format'
 
 class sdkMosaic {
+  // TODO(ahuszagh) Remove
   static init = async nodeUrl => {
-    NODE_URL = nodeUrl
-    ACCOUNT_HTTP = new AccountHttp(nodeUrl)
-    MOSAIC_HTTP = new MosaicHttp(nodeUrl)
-    NETWORK_HTTP = new NetworkHttp(nodeUrl)
   }
 
   static getMosaicsAmountByAddress = async address => {
-    const mosaicService = new MosaicService(
-      ACCOUNT_HTTP,
-      MOSAIC_HTTP
-    )
-    const mosaicAmount = await mosaicService
+    const mosaicAmount = await http.mosaicService
       .mosaicsAmountViewFromAddress(new Address(address))
       .toPromise()
 
@@ -64,8 +49,8 @@ class sdkMosaic {
 //      let namespaceId = new NamespaceId(mosaicHexOrNamespace)
 //      mosaicID = await NAMESPACE_HTTP.getLinkedMosaicId(namespaceId).toPromise()
 //    }
-//    // const mosaicInfo = await MOSAIC_HTTP.getMosaic(mosaicID).toPromise(); // SDK Break
-//    const mosaicName = await MOSAIC_HTTP.getMosaicsNames([mosaicID]).toPromise();
+//    // const mosaicInfo = await http.mosaic.getMosaic(mosaicID).toPromise(); // SDK Break
+//    const mosaicName = await http.mosaic.getMosaicsNames([mosaicID]).toPromise();
 //
 //    return format.formatMosaicInfo(mosaicInfo,mosaicName[0])
 //  }
@@ -79,9 +64,9 @@ class sdkMosaic {
     }
 
     // Make request.
-    const networkType = await NETWORK_HTTP.getNetworkType().toPromise()
+    const networkType = await http.network.getNetworkType().toPromise()
     const path = `/mosaics/from/${mosaicId}/limit/${limit}`
-    const response = await axios.get(NODE_URL + path)
+    const response = await axios.get(http.url + path)
     const mosaics = response.data.map(info => dto.createMosaicInfoFromDTO(info, networkType))
 
     return format.formatMosaicInfos(mosaics)
@@ -96,9 +81,9 @@ class sdkMosaic {
     }
 
     // Make request.
-    const networkType = await NETWORK_HTTP.getNetworkType().toPromise()
+    const networkType = await http.network.getNetworkType().toPromise()
     const path = `/mosaics/since/${mosaicId}/limit/${limit}`
-    const response = await axios.get(NODE_URL + path)
+    const response = await axios.get(http.url + path)
     const mosaics = response.data.map(info => dto.createMosaicInfoFromDTO(info, networkType))
 
     return format.formatMosaicInfos(mosaics)

--- a/src/infrastructure/getNamespace.js
+++ b/src/infrastructure/getNamespace.js
@@ -25,10 +25,6 @@ import format from '../format'
 import helper from '../helper'
 
 class sdkNamespace {
-  // TODO(ahuszagh) Remove
-  static init = async nodeUrl => {
-  }
-
   static getNamespacesFromAccountByAddress = async (address) => {
     const namespacesIds = []
     const namespaceList = await http.namespace

--- a/src/infrastructure/getTransaction.js
+++ b/src/infrastructure/getTransaction.js
@@ -30,10 +30,6 @@ import format from '../format'
 import sdkBlock from '../infrastructure/getBlock'
 
 class sdkTransaction {
-  // TODO(ahuszagh) Remove
-  static init = async nodeUrl => {
-  }
-
   static getAccountTransactions = async (address, transactionId = '') => {
     let pageSize = 100
 

--- a/src/infrastructure/getTransaction.js
+++ b/src/infrastructure/getTransaction.js
@@ -17,13 +17,7 @@
  */
 
 import axios from 'axios'
-import {
-  AccountHttp,
-  NetworkHttp,
-  TransactionHttp,
-  QueryParams,
-  Address
-} from 'nem2-sdk'
+import { QueryParams, Address } from 'nem2-sdk'
 import dto from './dto'
 import http from './http'
 import format from '../format'

--- a/src/infrastructure/getTransaction.js
+++ b/src/infrastructure/getTransaction.js
@@ -25,28 +25,19 @@ import {
   Address
 } from 'nem2-sdk'
 import dto from './dto'
+import http from './http'
 import format from '../format'
 import sdkBlock from '../infrastructure/getBlock'
 
-
-let TRANSACTION_HTTP
-let ACCOUNT_HTTP
-let NETWORK_HTTP
-let NODE_URL
-
-
 class sdkTransaction {
+  // TODO(ahuszagh) Remove
   static init = async nodeUrl => {
-    NODE_URL = nodeUrl
-    TRANSACTION_HTTP = new TransactionHttp(nodeUrl)
-    ACCOUNT_HTTP = new AccountHttp(nodeUrl)
-    NETWORK_HTTP = new NetworkHttp(nodeUrl)
   }
 
   static getAccountTransactions = async (address, transactionId = '') => {
     let pageSize = 100
 
-    const transactionsList = await ACCOUNT_HTTP
+    const transactionsList = await http.account
       .transactions(Address.createFromRawAddress(address), new QueryParams(pageSize, transactionId))
       .toPromise()
 
@@ -54,11 +45,11 @@ class sdkTransaction {
   }
 
   static getTransactionInfoByHash = async (hash) => {
-    const transaction = await TRANSACTION_HTTP.getTransaction(hash).toPromise()
+    const transaction = await http.transaction.getTransaction(hash).toPromise()
     const formattedTransaction = format.formatTransaction(transaction)
     const getBlockInfo = await sdkBlock.getBlockInfoByHeight(formattedTransaction.blockHeight)
 
-    const transactionStatus = await TRANSACTION_HTTP
+    const transactionStatus = await http.transaction
       .getTransactionStatus(hash)
       .toPromise()
 
@@ -100,8 +91,8 @@ class sdkTransaction {
     }
 
     // Make request.
-    const networkType = await NETWORK_HTTP.getNetworkType().toPromise()
-    const response = await axios.get(NODE_URL + path)
+    const networkType = await http.network.getNetworkType().toPromise()
+    const response = await axios.get(http.url + path)
     const transactions = response.data.map(info => dto.createTransactionFromDTO(info, networkType))
 
     return format.formatTransactions(transactions)
@@ -134,8 +125,8 @@ class sdkTransaction {
     }
 
     // Make request.
-    const networkType = await NETWORK_HTTP.getNetworkType().toPromise()
-    const response = await axios.get(NODE_URL + path)
+    const networkType = await http.network.getNetworkType().toPromise()
+    const response = await axios.get(http.url + path)
     const transactions = response.data.map(info => dto.createTransactionFromDTO(info, networkType))
 
     return format.formatTransactions(transactions)

--- a/src/infrastructure/http.js
+++ b/src/infrastructure/http.js
@@ -1,0 +1,66 @@
+/*
+ *
+ * Copyright (c) 2019-present for NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License ");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import store from '../store'
+import * as nem from 'nem2-sdk'
+
+export default class http {
+  static get url() {
+    return store.getters['api/currentNode'].url
+  }
+
+  static get account() {
+    return new nem.AccountHttp(http.url)
+  }
+
+  static get block() {
+    return new nem.BlockHttp(http.url)
+  }
+
+  static get chain() {
+    return new nem.ChainHttp(http.url)
+  }
+
+  static get diagnostic() {
+    return new nem.DiagnosticHttp(http.url)
+  }
+
+  static get mosaic() {
+    return new nem.MosaicHttp(http.url)
+  }
+
+  static get mosaicService() {
+    return new nem.MosaicService(http.account, http.mosaic)
+  }
+
+  static get namespace() {
+    return new nem.NamespaceHttp(http.url)
+  }
+
+  static get namespaceService() {
+    return new nem.NamespaceService(http.namespace)
+  }
+
+  static get network() {
+    return new nem.NetworkHttp(http.url)
+  }
+
+  static get transaction() {
+    return new nem.TransactionHttp(http.url)
+  }
+}

--- a/src/store/account.js
+++ b/src/store/account.js
@@ -62,14 +62,6 @@ export default {
   },
   actions: {
     async initialize({ dispatch }) {
-      dispatch('initializeSdk')
-    },
-
-    // Set node url to SDK
-    initializeSdk({rootGetters}) {
-      sdkAccount.init(rootGetters['api/currentNode'].url)
-      sdkTransaction.init(rootGetters['api/currentNode'].url)
-      sdkNamespace.init(rootGetters['api/currentNode'].url)
     },
 
     // Fetch data from the SDK By Address.

--- a/src/store/block.js
+++ b/src/store/block.js
@@ -92,7 +92,6 @@ export default {
     // Initialize the block model.
     // First fetch the page, then subscribe.
     async initialize({ dispatch }) {
-      dispatch('initializeSdk')
       await dispatch('initializePage')
       await dispatch('subscribe')
     },
@@ -124,11 +123,6 @@ export default {
     add({ commit }, item) {
       commit('chain/setBlockHeight', item.height, { root: true })
       commit('addLatestItem', item)
-    },
-
-    // Set node url to SDK
-    initializeSdk({rootGetters}) {
-      sdkBlock.init(rootGetters['api/currentNode'].url)
     },
 
     // Fetch data from the SDK and initialize the page.

--- a/src/store/chain.js
+++ b/src/store/chain.js
@@ -62,14 +62,7 @@ export default {
   actions: {
     // Initialize the chain model.
     async initialize({ dispatch }) {
-      dispatch('initializeSdk')
       await dispatch('initializePage')
-    },
-
-    // Set node url to SDK
-    initializeSdk({rootGetters}) {
-      apiMarketData.init(rootGetters['api/marketData'].url)
-      sdkDiagnostic.init(rootGetters['api/currentNode'].url)
     },
 
     // Fetch data from the SDK / API and initialize the page.

--- a/src/store/mosaic.js
+++ b/src/store/mosaic.js
@@ -56,13 +56,7 @@ export default {
     // Initialize the mosaic model.
     // First fetch the page, then subscribe.
     async initialize({ dispatch }) {
-      dispatch('initializeSdk')
       await dispatch('initializePage')
-    },
-      
-      // Set node url to SDK
-    initializeSdk({rootGetters}) {
-      sdkMosaic.init(rootGetters['api/currentNode'].url)
     },
 
     // Fetch data from the SDK and initialize the page.

--- a/src/store/namespace.js
+++ b/src/store/namespace.js
@@ -61,13 +61,7 @@ export default {
     // Initialize the namespace model.
     // First fetch the page, then subscribe.
     async initialize({ dispatch }) {
-      dispatch('initializeSdk')
       await dispatch('initializePage')
-    },
-      
-      // Set node url to SDK
-    initializeSdk({rootGetters}) {
-      sdkNamespace.init(rootGetters['api/currentNode'].url)
     },
 
     // Fetch data from the SDK and initialize the page.

--- a/src/store/transaction.js
+++ b/src/store/transaction.js
@@ -121,14 +121,8 @@ export default {
     // Initialize the transaction model.
     // First fetch the page, then subscribe.
     async initialize({ dispatch }) {
-      dispatch('initializeSdk')
       await dispatch('initializePage')
       await dispatch('subscribe')
-    },
-
-    // Set node url to SDK
-    initializeSdk({rootGetters}) {
-      sdkTransaction.init(rootGetters['api/currentNode'].url)
     },
 
     // Uninitialize the transaction model.


### PR DESCRIPTION
1. Removes the hacky `initializeSdk` methods.
2. Creates a helper class `http` with getters that create a wrapper to the client using the current node from the store.
3. Implemented all routes in terms of this helper.