### PR TITLE
Removed the use of global components and fixed component naming.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -19,17 +19,26 @@
 <template>
     <div id="app">
         <div class="app-content">
-            <top-header />
-            <page-menu />
+            <TopHeader />
+            <PageMenu />
             <router-view :key="$route.fullPath"/>
         </div>
-        <page-footer/>
+        <PageFooter />
     </div>
 </template>
 
 <script>
+import PageFooter from '@/components/PageFooter.vue'
+import PageMenu from './components/menu/PageMenu.vue'
+import TopHeader from '@/components/TopHeader.vue'
 
 export default {
+  components: {
+    PageFooter,
+    PageMenu,
+    TopHeader
+  },
+
   data: () => {
     return {
       info: 1

--- a/src/components/Age.vue
+++ b/src/components/Age.vue
@@ -17,17 +17,21 @@
  */
 
 <template>
-  <time-since :date="date">
+  <TimeSince :date="date">
     <template slot-scope="interval">
       {{timeSince(interval)}}
     </template>
-  </time-since>
+  </TimeSince>
 </template>
 <script>
+import TimeSince from '@/components/TimeSince.vue'
 import helper from '../helper'
 
 export default {
   name: 'Age',
+  components: {
+    TimeSince
+  },
   props: {
     date: String
   },

--- a/src/components/AggregateTransaction.vue
+++ b/src/components/AggregateTransaction.vue
@@ -6,7 +6,15 @@
 </template>
 
 <script>
+import TableListView from '@/components/tables/TableListView.vue'
+import TableInfoView from '@/components/tables/TableInfoView.vue'
+
 export default {
+  components: {
+    TableListView,
+    TableInfoView
+  },
+
   props: {
     transactionBody: {
       type: Object,

--- a/src/components/HomeBaseInfo.vue
+++ b/src/components/HomeBaseInfo.vue
@@ -18,7 +18,7 @@
 
 <template>
     <div class="widget bordr_rds_top0 network_info">
-        <loader
+        <Loading
             v-if="!marketData"
         />
         <div class="box">
@@ -49,11 +49,13 @@
 </template>
 <script>
 import HomeBaseInfoItem from '@/components/HomeBaseInfoItem.vue'
+import Loading from '@/components/Loading.vue'
 import { mapGetters } from 'vuex'
 
 export default {
   components: {
-    HomeBaseInfoItem
+    HomeBaseInfoItem,
+    Loading
   },
 
   computed: {

--- a/src/components/NemPriceGraph.vue
+++ b/src/components/NemPriceGraph.vue
@@ -18,7 +18,7 @@
 
 <template>
     <div class="widget m-0 z-1 nempricegraph_con bordr_rds_top0 pt-0 pb-0">
-        <loader
+        <Loading
             v-if="!marketData.historicalHourlyGraph.length > 0"
         />
         <ApexCharts
@@ -73,11 +73,13 @@
 </style>
 <script>
 import ApexCharts from '@/components/Chart.vue'
+import Loading from '@/components/Loading.vue'
 import { mapGetters } from 'vuex'
 
 export default {
   components: {
-    ApexCharts
+    ApexCharts,
+    Loading
   },
 
   computed: {

--- a/src/components/RecentBlocks.vue
+++ b/src/components/RecentBlocks.vue
@@ -37,7 +37,7 @@
                 </div>
             </div>
             <div class="box-con">
-                <loader
+                <Loading
                     v-if="loading"
                 />
                 <div class="row">
@@ -52,6 +52,7 @@
     </div>
 </template>
 <script>
+import Loading from '@/components/Loading.vue'
 import RecentBlockRow from '@/components/RecentBlockRow.vue'
 import { mapGetters } from 'vuex'
 
@@ -59,6 +60,7 @@ export default {
   name: 'RecentBlocks',
 
   components: {
+    Loading,
     RecentBlockRow
   },
 

--- a/src/components/RecentTransactions.vue
+++ b/src/components/RecentTransactions.vue
@@ -37,7 +37,7 @@
                 </div>
             </div>
             <div class="box-con">
-                <loader
+                <Loading
                     v-if="loading"
                 />
                 <div class="row">
@@ -52,6 +52,7 @@
     </div>
 </template>
 <script>
+import Loading from '@/components/Loading.vue'
 import RecentTransactionRow from '@/components/RecentTransactionRow.vue'
 import { mapGetters } from 'vuex'
 
@@ -59,6 +60,7 @@ export default {
   name: 'RecentTransactions',
 
   components: {
+    Loading,
     RecentTransactionRow
   },
 

--- a/src/components/TopHeader.vue
+++ b/src/components/TopHeader.vue
@@ -65,7 +65,7 @@ import LanguageSelector from '@/components/controls/LanguageSelector.vue'
 import SearchBox from '@/components/controls/SearchBox.vue'
 
 export default {
-  name: 'TopHead',
+  name: 'TopHeader',
 
   components: {
     MobileMenu,

--- a/src/components/containers/Card.vue
+++ b/src/components/containers/Card.vue
@@ -7,7 +7,7 @@
         </div>
 
         <div v-if="loading" class="card-loading">
-            <loader />
+            <Loading />
         </div>
 
         <div v-if="error" class="card-error">
@@ -22,8 +22,13 @@
 </template>
 
 <script>
+import Loading from '@/components/Loading.vue'
 
 export default {
+  components: {
+    Loading
+  },
+
   props: {
     loading: {
       type: Boolean,

--- a/src/main.js
+++ b/src/main.js
@@ -20,23 +20,9 @@ import Vue from 'vue'
 import App from './App.vue'
 import router from './router'
 import store from './store'
-import TopHead from '@/components/TopHead.vue'
-import PageMenu from './components/menu/PageMenu.vue'
-import Pagefooter from '@/components/PageFooter.vue'
-import TimeSince from '@/components/TimeSince.vue'
-import Loading from '@/components/Loading.vue'
-import TableListView from '@/components/tables/TableListView.vue'
-import TableInfoView from '@/components/tables/TableInfoView.vue'
 
 window.Vue = Vue
 Vue.config.productionTip = false
-Vue.component('top-header', TopHead)
-Vue.component('page-menu', PageMenu)
-Vue.component('page-footer', Pagefooter)
-Vue.component('time-since', TimeSince)
-Vue.component('loader', Loading)
-Vue.component('TableListView', TableListView)
-Vue.component('TableInfoView', TableInfoView)
 
 new Vue({
   router,

--- a/src/views/NamespaceDetail.vue
+++ b/src/views/NamespaceDetail.vue
@@ -55,17 +55,11 @@
     </div>
 </template>
 <script>
-import TableInfoView from '@/components/tables/TableInfoView.vue'
-import TableListView from '@/components/tables/TableListView.vue'
 import View from './View.vue'
 import { mapGetters } from 'vuex'
 
 export default {
   extends: View,
-  components: {
-    TableInfoView,
-    TableListView
-  },
 
   data() {
     return {


### PR DESCRIPTION
1. Removed global, registered components.
    - Mostly already registered under `View.vue`.
2. Removed redundant components in `NamespaceDetail.vue`
    - `TableInfoView`
    - `TableListView`
3. Extended `AggregateTransaction.vue` from `View.vue`
4. Renamed `TopHead.vue` to `TopHeader.vue`
    - Consistent with the previously used name.