### PR TITLE
Fix isHexadecimal to avoid redundant logic.

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -42,13 +42,7 @@ class helper {
   }
 
   static isHexadecimal(str) {
-    let regexp = /^[0-9a-fA-F]+$/
-
-    if (regexp.test(str)) {
-      return true
-    } else {
-      return false
-    }
+    return /^[0-9a-fA-F]+$/.test(str)
   }
 
   static validURL(_str) {


### PR DESCRIPTION
`RegExp.prototype.test` already can only return `true` or `false`, there is no need to have this superfluous logic.